### PR TITLE
Make exception string representations also the message

### DIFF
--- a/lib/cookbook-omnifetch/exceptions.rb
+++ b/lib/cookbook-omnifetch/exceptions.rb
@@ -50,6 +50,7 @@ module CookbookOmnifetch
     #   the path to the thing that is not a cookbook
     def initialize(path)
       @path = File.expand_path(path) rescue path
+      super(to_s)
     end
 
     def to_s
@@ -68,6 +69,7 @@ module CookbookOmnifetch
     def initialize(dependency, cached_cookbook)
       @dependency      = dependency
       @cached_cookbook = cached_cookbook
+      super(to_s)
     end
 
     def to_s
@@ -85,6 +87,7 @@ module CookbookOmnifetch
     def initialize(dependency, cached_cookbook)
       @dependency      = dependency
       @cached_cookbook = cached_cookbook
+      super(to_s)
     end
 
     def to_s
@@ -98,7 +101,7 @@ module CookbookOmnifetch
       out << "\n"
       out << "NOTE: If you do not explicitly set the 'name' attribute in the "
       out << "metadata, the name of the directory will be used instead. This "
-      out << "is often a cause of confusion for dependency solving."
+      out << "is often a cause of confusion for dependency solving.\n"
       out
     end
   end

--- a/spec/unit/exceptions_spec.rb
+++ b/spec/unit/exceptions_spec.rb
@@ -1,0 +1,87 @@
+require 'spec_helper'
+require 'cookbook-omnifetch/exceptions'
+
+module CookbookOmnifetch
+  describe "Exceptions" do
+
+    describe NotACookbook do
+
+      subject(:exception) do
+        described_class.new("/path/to/cookbook")
+      end
+
+      let(:message) do
+        "The resource at '/path/to/cookbook' does not appear to be a valid cookbook. Does it have a metadata.rb?"
+      end
+
+      it "creates an informative error in #message" do
+        expect(exception.message).to eq(message)
+      end
+
+      it "creates an informative error in #to_s" do
+        expect(exception.to_s).to eq(message)
+      end
+
+    end
+
+    describe CookbookValidationFailure do
+
+      let(:dependency) { instance_double("ChefDK::Policyfile::CookbookLocationSpecification", to_s: "apt ~> 1.2.3") }
+
+      # The exception class itself doesn't use this
+      let(:cached_cookbook) { Object.new }
+
+      subject(:exception) do
+        described_class.new(dependency, cached_cookbook)
+      end
+
+      let(:message) do
+        "The cookbook downloaded for apt ~> 1.2.3 did not satisfy the constraint."
+      end
+
+      it "creates an informative error in #message" do
+        expect(exception.message).to eq(message)
+      end
+
+      it "creates an informative error in #to_s" do
+        expect(exception.to_s).to eq(message)
+      end
+
+    end
+
+    describe MismatchedCookbookName do
+
+      let(:dependency) { instance_double("ChefDK::Policyfile::CookbookLocationSpecification", name: "apt") }
+
+      let(:cached_cookbook) { instance_double("Chef::Cookbook", cookbook_name: "apt") }
+
+      subject(:exception) do
+        described_class.new(dependency, cached_cookbook)
+      end
+
+      let(:message) do
+        <<-EOM
+In your Berksfile, you have:
+
+  cookbook 'apt'
+
+But that cookbook is actually named 'apt'
+
+This can cause potentially unwanted side-effects in the future.
+
+NOTE: If you do not explicitly set the 'name' attribute in the metadata, the name of the directory will be used instead. This is often a cause of confusion for dependency solving.
+EOM
+      end
+
+      it "creates an informative error in #message" do
+        expect(exception.message).to eq(message)
+      end
+
+      it "creates an informative error in #to_s" do
+        expect(exception.to_s).to eq(message)
+      end
+
+    end
+
+  end
+end


### PR DESCRIPTION
In ChefDK, we assume that `SomeException#message` will be informative, but the exception classes here assume you will be calling `SomeException#to_s`. By assigning `to_s` to `message`, we make everyone happy.

This is a partial fix for https://github.com/chef/chef-dk/issues/564 (need to ship, bump version constraint and apply a small fix to chef-dk for a similar error case)