### PR TITLE
prevent Minitar from incorrectly creating PaxHeader directories when handling archives created with BSD tar

### DIFF
--- a/lib/cookbook-omnifetch/artifactserver.rb
+++ b/lib/cookbook-omnifetch/artifactserver.rb
@@ -50,7 +50,10 @@ module CookbookOmnifetch
       Dir.mktmpdir(nil, staging_root) do |staging_dir|
         Zlib::GzipReader.open(cache_path) do |gz_file|
           tar = Archive::Tar::Minitar::Input.new(gz_file)
-          tar.each do |e|
+            # Minitar incorrectly handles archives created with BSD tar.
+            # Deal with the fallout.
+            tar.extract_entry(staging_dir, e) \
+              unless /PaxHeader/.match(e.full_name)
             tar.extract_entry(staging_dir, e)
           end
         end


### PR DESCRIPTION
Fixes https://github.com/chef/cookbook-omnifetch/issues/3 (and potentially https://github.com/chef/chef/issues/1660 as well).

I'm not sure this is the best approach, as it also prevents directories legitimately called "PaxHeader" from being extracted, but the only other alternative that I'm aware of is to shell out to tar, which is a whole new can of worms.