### PR TITLE
Multi thread example

### DIFF
--- a/demo.rb
+++ b/demo.rb
@@ -1,0 +1,56 @@
+$:.unshift File.expand_path("../lib", __FILE__)
+
+require "cookbook-omnifetch"
+require "chef/server_api"
+require "fileutils"
+
+p CookbookOmnifetch::VERSION
+
+Dep = Struct.new(:name)
+
+chef_server_url = "https://api.chef.io/organizations/chef-oss-dev"
+
+cb_name = "runit"
+cb_identifier = "09d43fad354b3efcc5b5836fef5137131f60f974"
+
+FileUtils.rm_rf("runit-09d43fad354b3efcc5b5836fef5137131f60f974")
+
+dep = Dep.new(cb_name)
+
+class ServerApiMulti
+
+  def initialize(url, opts={})
+    @url = url
+    @opts = opts
+  end
+
+  def get(*args)
+    client_for_thread.get(*args)
+  end
+
+  def streaming_request(*args)
+    client_for_thread.streaming_request(*args)
+  end
+
+  def client_for_thread
+    Thread.current[:server_api] ||= Chef::ServerAPI.new(@url, @opts)
+  end
+
+end
+
+http_client = ServerApiMulti.new(chef_server_url,
+                                 client_name: 'kallistec',
+                                 signing_key_filename: '/Users/ddeleo/opscode-ops/chef-oss-dev/.chef/kallistec.pem',
+                                 keepalives: true)
+
+fetcher = CookbookOmnifetch.init(dep, chef_server_artifact: chef_server_url, identifier: cb_identifier, http_client: http_client)
+
+#p fetcher
+
+CookbookOmnifetch.configure do |c|
+  c.cache_path = Pathname.new(Dir.pwd)
+  c.storage_path = Pathname.new(Dir.pwd)
+end
+
+fetcher.install
+

--- a/lib/cookbook-omnifetch.rb
+++ b/lib/cookbook-omnifetch.rb
@@ -8,6 +8,7 @@ require "cookbook-omnifetch/path"
 require "cookbook-omnifetch/artifactserver"
 require "cookbook-omnifetch/artifactory"
 require "cookbook-omnifetch/chef_server"
+require "cookbook-omnifetch/chef_server_artifact"
 
 module CookbookOmnifetch
 

--- a/lib/cookbook-omnifetch/chef_server.rb
+++ b/lib/cookbook-omnifetch/chef_server.rb
@@ -1,35 +1,7 @@
 require "cookbook-omnifetch/base"
+require "cookbook-omnifetch/metadata_based_installer"
 
 module CookbookOmnifetch
-  class CookbookMetadata
-
-    FILE_TYPES = [
-      :resources,
-      :providers,
-      :recipes,
-      :definitions,
-      :libraries,
-      :attributes,
-      :files,
-      :templates,
-      :root_files,
-    ].freeze
-
-    def initialize(metadata)
-      @metadata = metadata
-    end
-
-    def files(&block)
-      FILE_TYPES.each do |type|
-        next unless @metadata.has_key?(type.to_s)
-
-        @metadata[type.to_s].each do |file|
-          yield file["url"], file["path"]
-        end
-      end
-    end
-  end
-
   class ChefServerLocation < BaseLocation
 
     attr_reader :cookbook_version
@@ -42,27 +14,20 @@ module CookbookOmnifetch
       @uri ||= options[:chef_server]
     end
 
-    def repo_host
-      @host ||= URI.parse(uri).host
-    end
-
     def cookbook_name
       dependency.name
     end
 
-    def install
-      FileUtils.mkdir_p(staging_root) unless staging_root.exist?
-      md = http_client.get("/cookbooks/#{cookbook_name}/#{cookbook_version}")
-      CookbookMetadata.new(md).files do |url, path|
-        stage = staging_path.join(path)
-        FileUtils.mkdir_p(File.dirname(stage))
+    def url_path
+      "/cookbooks/#{cookbook_name}/#{cookbook_version}"
+    end
 
-        http_client.streaming_request(url) do |tempfile|
-          tempfile.close
-          FileUtils.mv(tempfile.path, stage)
-        end
-      end
-      FileUtils.mv(staging_path, install_path)
+    def installer
+      MetadataBasedInstaller.new(http_client: http_client, url_path: url_path, install_path: install_path)
+    end
+
+    def install
+      installer.install
     end
 
     # Determine if this revision is installed.
@@ -92,22 +57,5 @@ module CookbookOmnifetch
       "#{dependency.name}-#{cookbook_version}"
     end
 
-    # The path where tarballs are downloaded to and unzipped.  On certain platforms
-    # you have a better chance of getting an atomic move if your temporary working
-    # directory is on the same device/volume as the  destination.  To support this,
-    # we use a staging directory located under the cache path under the rather mild
-    # assumption that everything under the cache path is going to be on one device.
-    #
-    # Do not create anything under this directory that isn't randomly named and
-    # remember to release your files once you are done.
-    #
-    # @return [Pathname]
-    def staging_root
-      Pathname.new(CookbookOmnifetch.cache_path).join(".cache_tmp", "artifactserver")
-    end
-
-    def staging_path
-      staging_root.join(cache_key)
-    end
   end
 end

--- a/lib/cookbook-omnifetch/chef_server_artifact.rb
+++ b/lib/cookbook-omnifetch/chef_server_artifact.rb
@@ -1,0 +1,113 @@
+require "cookbook-omnifetch/base"
+
+module CookbookOmnifetch
+  class CookbookMetadata
+
+    FILE_TYPES = [
+      :resources,
+      :providers,
+      :recipes,
+      :definitions,
+      :libraries,
+      :attributes,
+      :files,
+      :templates,
+      :root_files,
+    ].freeze
+
+    def initialize(metadata)
+      @metadata = metadata
+    end
+
+    def files(&block)
+      FILE_TYPES.each do |type|
+        next unless @metadata.has_key?(type.to_s)
+
+        @metadata[type.to_s].each do |file|
+          yield file["url"], file["path"]
+        end
+      end
+    end
+  end
+
+  class ChefServerArtifactLocation < BaseLocation
+
+    attr_reader :cookbook_identifier
+    attr_reader :uri
+
+    def initialize(dependency, options = {})
+      super
+      @cookbook_identifier = options[:identifier]
+      @http_client = options[:http_client]
+      @uri ||= options[:chef_server_artifact]
+    end
+
+    def repo_host
+      @host ||= URI.parse(uri).host
+    end
+
+    def cookbook_name
+      dependency.name
+    end
+
+    def install
+      FileUtils.mkdir_p(staging_root) unless staging_root.exist?
+      md = http_client.get("/cookbook_artifacts/#{cookbook_name}/#{cookbook_identifier}")
+      CookbookMetadata.new(md).files do |url, path|
+        stage = staging_path.join(path)
+        FileUtils.mkdir_p(File.dirname(stage))
+
+        http_client.streaming_request(url) do |tempfile|
+          tempfile.close
+          FileUtils.mv(tempfile.path, stage)
+        end
+      end
+      FileUtils.mv(staging_path, install_path)
+    end
+
+    # Determine if this revision is installed.
+    #
+    # @return [Boolean]
+    def installed?
+      install_path.exist?
+    end
+
+    def http_client
+      @http_client
+    end
+
+    # The path where this cookbook would live in the store, if it were
+    # installed.
+    #
+    # @return [Pathname, nil]
+    def install_path
+      @install_path ||= CookbookOmnifetch.storage_path.join(cache_key)
+    end
+
+    def lock_data
+      { "chef_server" => uri, "server_identifier" => cookbook_identifier }
+    end
+
+    def cache_key
+      "#{dependency.name}-#{cookbook_identifier}"
+    end
+
+    # The path where tarballs are downloaded to and unzipped.  On certain platforms
+    # you have a better chance of getting an atomic move if your temporary working
+    # directory is on the same device/volume as the  destination.  To support this,
+    # we use a staging directory located under the cache path under the rather mild
+    # assumption that everything under the cache path is going to be on one device.
+    #
+    # Do not create anything under this directory that isn't randomly named and
+    # remember to release your files once you are done.
+    #
+    # @return [Pathname]
+    def staging_root
+      Pathname.new(CookbookOmnifetch.cache_path).join(".cache_tmp", "artifactserver")
+    end
+
+    def staging_path
+      staging_root.join(cache_key)
+    end
+  end
+end

--- a/lib/cookbook-omnifetch/metadata_based_installer.rb
+++ b/lib/cookbook-omnifetch/metadata_based_installer.rb
@@ -1,0 +1,82 @@
+
+module CookbookOmnifetch
+
+  class MetadataBasedInstaller
+    class CookbookMetadata
+
+      FILE_TYPES = [
+        :resources,
+        :providers,
+        :recipes,
+        :definitions,
+        :libraries,
+        :attributes,
+        :files,
+        :templates,
+        :root_files,
+      ].freeze
+
+      def initialize(metadata)
+        @metadata = metadata
+      end
+
+      def files(&block)
+        FILE_TYPES.each do |type|
+          next unless @metadata.has_key?(type.to_s)
+
+          @metadata[type.to_s].each do |file|
+            yield file["url"], file["path"]
+          end
+        end
+      end
+    end
+
+    attr_reader :http_client
+    attr_reader :url_path
+    attr_reader :install_path
+
+    def initialize(http_client:, url_path:, install_path:)
+      @http_client = http_client
+      @url_path = url_path
+      @install_path = install_path
+    end
+
+    def install
+      FileUtils.mkdir_p(staging_root) unless staging_root.exist?
+      md = http_client.get(url_path)
+      CookbookMetadata.new(md).files do |url, path|
+        stage = staging_path.join(path)
+        FileUtils.mkdir_p(File.dirname(stage))
+
+        http_client.streaming_request(url) do |tempfile|
+          tempfile.close
+          FileUtils.mv(tempfile.path, stage)
+        end
+      end
+      FileUtils.mv(staging_path, install_path)
+    end
+
+    # The path where tarballs are downloaded to and unzipped.  On certain platforms
+    # you have a better chance of getting an atomic move if your temporary working
+    # directory is on the same device/volume as the  destination.  To support this,
+    # we use a staging directory located under the cache path under the rather mild
+    # assumption that everything under the cache path is going to be on one device.
+    #
+    # Do not create anything under this directory that isn't randomly named and
+    # remember to release your files once you are done.
+    #
+    # @return [Pathname]
+    def staging_root
+      Pathname.new(CookbookOmnifetch.cache_path).join(".cache_tmp", "artifactserver")
+    end
+
+    def staging_path
+      staging_root.join(staging_cache_key)
+    end
+
+    def staging_cache_key
+      url_path.gsub(/[^[:alnum:]]/, '_')
+    end
+  end
+end
+

--- a/spec/unit/chef_server_artifact_spec.rb
+++ b/spec/unit/chef_server_artifact_spec.rb
@@ -1,0 +1,74 @@
+require "spec_helper"
+require "cookbook-omnifetch/chef_server.rb"
+
+RSpec.describe CookbookOmnifetch::ChefServerArtifactLocation do
+
+  let(:http_client) { double("Http Client") }
+
+  let(:test_root) { "/some/fake/path" }
+
+  let(:storage_path) { File.join(test_root, "storage") }
+
+  let(:dependency) { double("Dependency", name: cookbook_name) }
+
+  let(:cookbook_name) { "example" }
+
+  let(:cookbook_identifier) { "467dc855408ce8b74f991c5dc2fd72a6aa369b60" }
+
+  let(:url) { "https://chef.example.com/organizations/example" }
+
+  let(:options) { { chef_server_artifact: url, identifier: cookbook_identifier, http_client: http_client } }
+
+  let(:expected_cache_key) { "example-467dc855408ce8b74f991c5dc2fd72a6aa369b60" }
+
+  subject(:chef_server_artifact_location) { described_class.new(dependency, options) }
+
+  before do
+    allow(CookbookOmnifetch).to receive(:storage_path).and_return(Pathname.new(storage_path))
+  end
+
+  it "has a URI" do
+    expect(chef_server_artifact_location.uri).to eq(url)
+  end
+
+  it "has an HTTP client" do
+    expect(chef_server_artifact_location.http_client).to eq(http_client)
+  end
+
+  it "has a metadata_based_installer" do
+    installer = chef_server_artifact_location.installer
+    expect(installer).to be_a(CookbookOmnifetch::MetadataBasedInstaller)
+    expect(installer.http_client).to eq(http_client)
+    expect(installer.url_path).to eq("/cookbook_artifacts/example/467dc855408ce8b74f991c5dc2fd72a6aa369b60")
+    expect(installer.install_path.to_s).to eq(File.join(storage_path, expected_cache_key))
+  end
+
+  it "has a cache key containing the site URI and version" do
+    expect(chef_server_artifact_location.cache_key).to eq(expected_cache_key)
+  end
+
+  it "has an identifier" do
+    expect(chef_server_artifact_location.cookbook_identifier).to eq(cookbook_identifier)
+  end
+
+  it "provides lock data as a Hash" do
+    expected_data = {
+      "chef_server" => url,
+      "server_identifier" => cookbook_identifier,
+    }
+    expect(chef_server_artifact_location.lock_data).to eq(expected_data)
+  end
+
+  describe "when installing" do
+
+    let(:installer) { instance_double("CookbookOmnifetch::MetadataBasedInstaller") }
+
+    it "delegates to the MetadataBasedInstaller" do
+      allow(chef_server_artifact_location).to receive(:installer).and_return(installer)
+      expect(installer).to receive(:install)
+      chef_server_artifact_location.install
+    end
+
+  end
+
+end

--- a/spec/unit/metadata_based_installer_spec.rb
+++ b/spec/unit/metadata_based_installer_spec.rb
@@ -1,0 +1,114 @@
+require "spec_helper"
+require "cookbook-omnifetch/metadata_based_installer.rb"
+
+RSpec.shared_context "sample_metadata" do
+
+  let(:raw_metadata) do
+    {
+      "recipes" => [
+        { "name" => "default.rb", "path" => "recipes/default.rb", "checksum" => "a6be794cdd2eb44d38fdf17f792a0d0d", "specificity" => "default", "url" => "https://example.com/recipes/default.rb" },
+      ],
+      "root_files" => [
+        { "name" => "metadata.rb", "path" => "metadata.rb", "checksum" => "5b346119e5e41ab99500608decac8dca", "specificity" => "default", "url" => "https://example.com/metadata.rb" },
+      ],
+    }
+
+  end
+end
+
+RSpec.describe CookbookOmnifetch::MetadataBasedInstaller::CookbookMetadata do
+
+  include_context "sample_metadata"
+
+  subject(:cb_metadata) { described_class.new(raw_metadata) }
+
+  it "yields a set of paths and urls" do
+    expect { |b| cb_metadata.files(&b) }.to yield_successive_args(["https://example.com/recipes/default.rb", "recipes/default.rb"], ["https://example.com/metadata.rb", "metadata.rb"])
+  end
+end
+
+RSpec.describe CookbookOmnifetch::MetadataBasedInstaller do
+
+  include_context "sample_metadata"
+
+  let(:url_path) { "/cookbooks/example/0.5.0" }
+
+  let(:http_client) do
+    double("Http Client")
+  end
+
+  let(:recipe_url) do
+    raw_metadata["recipes"][0]["url"]
+  end
+
+  let(:recipe_path) do
+    raw_metadata["recipes"][0]["path"]
+  end
+
+  let(:recipe_filehandle) do
+    File.open(File.join(remote_path, recipe_path))
+  end
+
+  let(:root_file_url) do
+    raw_metadata["root_files"][0]["url"]
+  end
+
+  let(:root_file_path) do
+    raw_metadata["root_files"][0]["path"]
+  end
+
+  let(:root_file_filehandle) do
+    File.open(File.join(remote_path, root_file_path))
+  end
+
+  let(:cookbook_fixture_path) { fixtures_path.join("cookbooks/example_cookbook") }
+
+  let(:test_root) { Dir.mktmpdir(nil) }
+
+  let(:remote_path) { File.join(test_root, "remote") }
+
+  let(:install_path) { File.join(test_root, "install_path") }
+
+  let(:cookbook_files) { %w{metadata.rb recipes recipes/default.rb} }
+
+  let(:expected_installed_files) do
+    cookbook_files.map do |file|
+      File.join(install_path, file)
+    end
+  end
+
+  subject(:installer) do
+    described_class.new(http_client: http_client,
+                        url_path: url_path,
+                        install_path: install_path)
+  end
+
+  before do
+    FileUtils.cp_r(cookbook_fixture_path, remote_path)
+
+    expect(http_client).to receive(:get).
+      with(url_path).
+      and_return(raw_metadata)
+    expect(http_client).to receive(:streaming_request).
+      with(recipe_url).
+      and_yield(recipe_filehandle)
+    expect(http_client).to receive(:streaming_request).
+      with(root_file_url).
+      and_yield(root_file_filehandle)
+  end
+
+  after do
+    FileUtils.rm_r(test_root)
+  end
+
+  it "installs the cookbook to the desired install path" do
+    expect(Dir).to_not exist(install_path)
+
+    installer.install
+
+    expect(Dir).to exist(install_path)
+    expect(Dir.glob("#{install_path}/**/*")).to match_array(expected_installed_files)
+  end
+
+end
+


### PR DESCRIPTION
JUST FOR DISCUSSION

ALSO the only relevant commit is the last one, the prior commits come from https://github.com/chef/cookbook-omnifetch/pull/17

The `chef_server` source in policyfiles is pretty slow. Unfortunately we can't just throw threads at it because `Chef::HTTP` (parent of `Chef::ServerAPI`) can't have multiple requests from different threads being made with the same `Chef::HTTP` object at the same time. But we can make a wrapper around `Chef::ServerAPI` to make it work. We'd likely have to add some config option to enable thread mode, then put `Chef::ServerAPIMulti` in ChefDK or something.

Thoughts?
