### PR TITLE
Default Chef Server HTTP client, implement cached_cookbook, fix lock data

### DIFF
--- a/lib/cookbook-omnifetch.rb
+++ b/lib/cookbook-omnifetch.rb
@@ -124,6 +124,10 @@ module CookbookOmnifetch
     integration.chef_server_download_concurrency
   end
 
+  def self.default_chef_server_http_client
+    integration.default_chef_server_http_client
+  end
+
   # Returns true or false if the given path contains a Chef Cookbook
   #
   # @param [#to_s] path

--- a/lib/cookbook-omnifetch/chef_server.rb
+++ b/lib/cookbook-omnifetch/chef_server.rb
@@ -10,7 +10,7 @@ module CookbookOmnifetch
     def initialize(dependency, options = {})
       super
       @cookbook_version = options[:version]
-      @http_client = options[:http_client]
+      @http_client = options[:http_client] || default_chef_server_http_client
       @uri ||= options[:chef_server]
     end
 
@@ -55,6 +55,12 @@ module CookbookOmnifetch
 
     def cache_key
       "#{dependency.name}-#{cookbook_version}"
+    end
+
+    private
+
+    def default_chef_server_http_client
+      CookbookOmnifetch.default_chef_server_http_client
     end
 
   end

--- a/lib/cookbook-omnifetch/chef_server.rb
+++ b/lib/cookbook-omnifetch/chef_server.rb
@@ -57,6 +57,11 @@ module CookbookOmnifetch
       "#{dependency.name}-#{cookbook_version}"
     end
 
+    # @see BaseLocation#cached_cookbook
+    def cached_cookbook
+      @cached_cookbook ||= CookbookOmnifetch.cached_cookbook_class.from_path(install_path)
+    end
+
     private
 
     def default_chef_server_http_client

--- a/lib/cookbook-omnifetch/chef_server_artifact.rb
+++ b/lib/cookbook-omnifetch/chef_server_artifact.rb
@@ -61,7 +61,7 @@ module CookbookOmnifetch
     end
 
     def lock_data
-      { "chef_server" => uri, "server_identifier" => cookbook_identifier }
+      { "chef_server_artifact" => uri, "identifier" => cookbook_identifier }
     end
 
     def cache_key

--- a/lib/cookbook-omnifetch/chef_server_artifact.rb
+++ b/lib/cookbook-omnifetch/chef_server_artifact.rb
@@ -68,6 +68,11 @@ module CookbookOmnifetch
       "#{dependency.name}-#{cookbook_identifier}"
     end
 
+    # @see BaseLocation#cached_cookbook
+    def cached_cookbook
+      @cached_cookbook ||= CookbookOmnifetch.cached_cookbook_class.from_path(install_path)
+    end
+
     private
 
     def default_chef_server_http_client

--- a/lib/cookbook-omnifetch/chef_server_artifact.rb
+++ b/lib/cookbook-omnifetch/chef_server_artifact.rb
@@ -17,7 +17,7 @@ module CookbookOmnifetch
     def initialize(dependency, options = {})
       super
       @cookbook_identifier = options[:identifier]
-      @http_client = options[:http_client]
+      @http_client = options[:http_client] || default_chef_server_http_client
       @uri ||= options[:chef_server_artifact]
     end
 
@@ -66,6 +66,12 @@ module CookbookOmnifetch
 
     def cache_key
       "#{dependency.name}-#{cookbook_identifier}"
+    end
+
+    private
+
+    def default_chef_server_http_client
+      CookbookOmnifetch.default_chef_server_http_client
     end
 
   end

--- a/lib/cookbook-omnifetch/integration.rb
+++ b/lib/cookbook-omnifetch/integration.rb
@@ -39,6 +39,11 @@ module CookbookOmnifetch
     # commentary in cookbook_omnifetch.rb
     configurable :chef_server_download_concurrency
 
+    # HTTP client object that will be used for source option `http_client` by
+    # `ChefServerLocation` and `ChefServerArtifactLocation` if not explicitly
+    # passed
+    configurable :default_chef_server_http_client
+
     def initialize
       self.class.configurables.each do |configurable|
         instance_variable_set("@#{configurable}".to_sym, NullValue.new)

--- a/spec/unit/chef_server_artifact_spec.rb
+++ b/spec/unit/chef_server_artifact_spec.rb
@@ -59,6 +59,35 @@ RSpec.describe CookbookOmnifetch::ChefServerArtifactLocation do
     expect(chef_server_artifact_location.lock_data).to eq(expected_data)
   end
 
+  context "when using the default chef server HTTP client" do
+
+    let(:options) { { chef_server_artifact: url, identifier: cookbook_identifier } }
+
+    let(:default_http_client) { double("Http Client") }
+
+    before do
+      CookbookOmnifetch.integration.default_chef_server_http_client = default_http_client
+    end
+
+    after do
+      CookbookOmnifetch.integration.default_chef_server_http_client = nil
+    end
+
+    it "uses the default http client for requests" do
+      expect(chef_server_artifact_location.http_client).to eq(default_http_client)
+    end
+
+    context "and an http client is explicitly passed" do
+
+      let(:options) { { chef_server: url, identifier: cookbook_identifier, http_client: http_client } }
+
+      it "uses the explicitly passed client instead of the default" do
+        expect(chef_server_artifact_location.http_client).to eq(http_client)
+      end
+
+    end
+  end
+
   describe "when installing" do
 
     let(:installer) { instance_double("CookbookOmnifetch::MetadataBasedInstaller") }

--- a/spec/unit/chef_server_artifact_spec.rb
+++ b/spec/unit/chef_server_artifact_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe CookbookOmnifetch::ChefServerArtifactLocation do
 
   let(:expected_cache_key) { "example-467dc855408ce8b74f991c5dc2fd72a6aa369b60" }
 
+  let(:expected_install_path) { File.join(storage_path, expected_cache_key) }
+
   subject(:chef_server_artifact_location) { described_class.new(dependency, options) }
 
   before do
@@ -40,7 +42,7 @@ RSpec.describe CookbookOmnifetch::ChefServerArtifactLocation do
     expect(installer).to be_a(CookbookOmnifetch::MetadataBasedInstaller)
     expect(installer.http_client).to eq(http_client)
     expect(installer.url_path).to eq("/cookbook_artifacts/example/467dc855408ce8b74f991c5dc2fd72a6aa369b60")
-    expect(installer.install_path.to_s).to eq(File.join(storage_path, expected_cache_key))
+    expect(installer.install_path.to_s).to eq(expected_install_path)
   end
 
   it "has a cache key containing the site URI and version" do
@@ -57,6 +59,11 @@ RSpec.describe CookbookOmnifetch::ChefServerArtifactLocation do
       "identifier" => cookbook_identifier,
     }
     expect(chef_server_artifact_location.lock_data).to eq(expected_data)
+  end
+
+  it "returns a cached cookbook object" do
+    expect(MockCachedCookbook).to receive(:from_path).with(Pathname.new(expected_install_path))
+    chef_server_artifact_location.cached_cookbook
   end
 
   context "when using the default chef server HTTP client" do

--- a/spec/unit/chef_server_artifact_spec.rb
+++ b/spec/unit/chef_server_artifact_spec.rb
@@ -53,8 +53,8 @@ RSpec.describe CookbookOmnifetch::ChefServerArtifactLocation do
 
   it "provides lock data as a Hash" do
     expected_data = {
-      "chef_server" => url,
-      "server_identifier" => cookbook_identifier,
+      "chef_server_artifact" => url,
+      "identifier" => cookbook_identifier,
     }
     expect(chef_server_artifact_location.lock_data).to eq(expected_data)
   end

--- a/spec/unit/chef_server_spec.rb
+++ b/spec/unit/chef_server_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe CookbookOmnifetch::ChefServerLocation do
 
   let(:options) { { chef_server: url, version: cookbook_version, http_client: http_client } }
 
+  let(:expected_install_path) { File.join(storage_path, "example-0.5.0") }
+
   subject(:chef_server_location) { described_class.new(dependency, options) }
 
   before do
@@ -38,7 +40,7 @@ RSpec.describe CookbookOmnifetch::ChefServerLocation do
     expect(installer).to be_a(CookbookOmnifetch::MetadataBasedInstaller)
     expect(installer.http_client).to eq(http_client)
     expect(installer.url_path).to eq("/cookbooks/example/0.5.0")
-    expect(installer.install_path.to_s).to eq(File.join(storage_path, "example-0.5.0"))
+    expect(installer.install_path.to_s).to eq(expected_install_path)
   end
 
   it "has a cache key containing the site URI and version" do
@@ -57,6 +59,10 @@ RSpec.describe CookbookOmnifetch::ChefServerLocation do
     expect(chef_server_location.lock_data).to eq(expected_data)
   end
 
+  it "returns a cached cookbook object" do
+    expect(MockCachedCookbook).to receive(:from_path).with(Pathname.new(expected_install_path))
+    chef_server_location.cached_cookbook
+  end
 
   context "when using the default chef server HTTP client" do
 

--- a/spec/unit/chef_server_spec.rb
+++ b/spec/unit/chef_server_spec.rb
@@ -57,6 +57,36 @@ RSpec.describe CookbookOmnifetch::ChefServerLocation do
     expect(chef_server_location.lock_data).to eq(expected_data)
   end
 
+
+  context "when using the default chef server HTTP client" do
+
+    let(:options) { { chef_server_artifact: url, version: cookbook_version } }
+
+    let(:default_http_client) { double("Http Client") }
+
+    before do
+      CookbookOmnifetch.integration.default_chef_server_http_client = default_http_client
+    end
+
+    after do
+      CookbookOmnifetch.integration.default_chef_server_http_client = nil
+    end
+
+    it "uses the default http client for requests" do
+      expect(chef_server_location.http_client).to eq(default_http_client)
+    end
+
+    context "and an http client is explicitly passed" do
+
+      let(:options) { { chef_server: url, version: cookbook_version, http_client: http_client } }
+
+      it "uses the explicitly passed client instead of the default" do
+        expect(chef_server_location.http_client).to eq(http_client)
+      end
+
+    end
+  end
+
   describe "when installing" do
 
     let(:installer) { instance_double("CookbookOmnifetch::MetadataBasedInstaller") }


### PR DESCRIPTION
* Adds configurable default HTTP client for Chef Server communication. This prevents the need for us to thread `chef_config` all over the place in ChefDK and makes the cookbook omnifetch abstraction less leaky from that side.
* Fixes the lock data for the Chef Server Artifact Location--the lock data emitted needs to be "round-trip-able" such that feeding it to `CookbookOmnifetch.init` will return the same location object type. If not, `chef install` with a lockfile present will error out trying to locate/install the cookbook
* Implement `#cached_cookbook` for Chef Server and Chef Server Artifact locations -- this is invoked when cookbooks must be "pre-fetched" in order to feed the correct constraints to the solver, such as when there's a `cookbook "foo", options` line in the Policyfile.rb.