### PR TITLE
Require Ruby 2.4 or later

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -1,5 +1,15 @@
 ---
 steps:
+- label: run-specs-ruby-2.4
+  command:
+    - bundle install --jobs=7 --retry=3 --without docs development
+    - export USER="root"
+    - bundle exec rspec
+  expeditor:
+    executor:
+      docker:
+        image: ruby:2.4-stretch
+
 - label: run-specs-ruby-2.5
   command:
     - bundle install --jobs=7 --retry=3 --without docs development

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 #### Merged Pull Requests
 - Add boilerplate files and resolve chefstyle warnings [#26](https://github.com/chef/cookbook-omnifetch/pull/26) ([tas50](https://github.com/tas50)) <!-- 0.8.2 -->
 - Wire up in Expeditor / Buildkite for release and testing [#25](https://github.com/chef/cookbook-omnifetch/pull/25) ([tas50](https://github.com/tas50)) <!-- 0.8.1 -->
+- Fix 'chef install foo.lock.json' cookbook loading from Artifactory [#24](https://github.com/chef/cookbook-omnifetch/pull/24) ([mattray](https://github.com/mattray)) <!-- n/a -->
 <!-- release_rollup -->
 
 <!-- latest_stable_release -->

--- a/cookbook-omnifetch.gemspec
+++ b/cookbook-omnifetch.gemspec
@@ -26,6 +26,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/chef/cookbook-omnifetch"
   spec.license       = "Apache-2.0"
 
+  spec.required_ruby_version = ">= 2.4"
+
   spec.files         = `git ls-files -z`.split("\x0").grep(/LICENSE|^lib/)
   spec.require_paths = ["lib"]
 


### PR DESCRIPTION
We tested on 2.3+ previously but didn't call out what version of ruby we
required.

Signed-off-by: Tim Smith <tsmith@chef.io>