### PR TITLE
Optimize our requires

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,7 @@ rescue LoadError
 end
 
 begin
-  require "yard"
+  require "yard" unless defined?(YARD)
   YARD::Rake::YardocTask.new(:docs)
 rescue LoadError
   puts "yard is not available. bundle install first to make sure all dependencies are installed."

--- a/lib/cookbook-omnifetch/artifactory.rb
+++ b/lib/cookbook-omnifetch/artifactory.rb
@@ -1,7 +1,7 @@
 require_relative "base"
 
-require "mixlib/archive"
-require "tmpdir"
+require "mixlib/archive" unless defined?(Mixlib::Archive)
+require "tmpdir" unless defined?(Dir.mktmpdir)
 
 module CookbookOmnifetch
 

--- a/lib/cookbook-omnifetch/artifactserver.rb
+++ b/lib/cookbook-omnifetch/artifactserver.rb
@@ -1,7 +1,7 @@
 require_relative "base"
 
-require "mixlib/archive"
-require "tmpdir"
+require "mixlib/archive" unless defined?(Mixlib::Archive)
+require "tmpdir" unless defined?(Dir.mktmpdir)
 
 module CookbookOmnifetch
 

--- a/lib/cookbook-omnifetch/git.rb
+++ b/lib/cookbook-omnifetch/git.rb
@@ -1,4 +1,4 @@
-require "tmpdir"
+require "tmpdir" unless defined?(Dir.mktmpdir)
 require_relative "../cookbook-omnifetch"
 require_relative "base"
 require_relative "exceptions"

--- a/spec/unit/artifactory_spec.rb
+++ b/spec/unit/artifactory_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 require "cookbook-omnifetch/artifactory"
-require "zlib"
+require "zlib" unless defined?(Zlib)
 require "archive/tar/minitar"
 
 module CookbookOmnifetch

--- a/spec/unit/artifactserver_spec.rb
+++ b/spec/unit/artifactserver_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 require "cookbook-omnifetch/artifactserver"
-require "zlib"
+require "zlib" unless defined?(Zlib)
 require "archive/tar/minitar"
 
 module CookbookOmnifetch


### PR DESCRIPTION
Avoid requiring things that are already defined. Rubygems is very slow at traversing the filesystem.

Signed-off-by: Tim Smith <tsmith@chef.io>