### PR TITLE
Don't use git filter-branch when installing from git with rel path

### DIFF
--- a/lib/cookbook-omnifetch/git.rb
+++ b/lib/cookbook-omnifetch/git.rb
@@ -60,7 +60,7 @@ module CookbookOmnifetch
         git %{reset --hard #{@revision}}
 
         if rel
-          git %{filter-branch --subdirectory-filter "#{rel}" --force}
+          scratch_path = File.join(scratch_path, rel)
         end
       end
 

--- a/spec/unit/git_spec.rb
+++ b/spec/unit/git_spec.rb
@@ -119,6 +119,7 @@ module CookbookOmnifetch
           expect(subject).to receive(:git).with(
             'fetch --force --tags https://repo.com "refs/heads/*:refs/heads/*"'
           )
+          expect(FileUtils).to receive(:cp_r).with(/#{File::SEPARATOR}hi$/, anything)
           subject.install
         end
       end
@@ -132,6 +133,7 @@ module CookbookOmnifetch
           expect(subject).to receive(:git).with(
             %{clone https://repo.com "#{cache_path}" --bare --no-hardlinks}
           )
+          expect(FileUtils).to receive(:cp_r).with(/#{File::SEPARATOR}hi$/, anything)
           subject.install
         end
       end


### PR DESCRIPTION
## Description
Stop using git filter-branch to filter for "rel" subpaths when installing cookbooks from Git:
- git filter-branch is deprecated and takes a very long time to run
- Since the code ends up removing .git directories, it's not important to keep the history which would be a primary reason for using git filter-branch in the first place

On a given private cookbook, the installation process drops from ~15 to 3s

## Types of changes
- [X] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
