### PR TITLE
Restore functionality of installed? and reintroduce staging area for ChefServer locations

### DIFF
--- a/cookbook-omnifetch.gemspec
+++ b/cookbook-omnifetch.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "cookbook-omnifetch/version"
 

--- a/lib/cookbook-omnifetch/chef_server.rb
+++ b/lib/cookbook-omnifetch/chef_server.rb
@@ -34,8 +34,7 @@ module CookbookOmnifetch
     #
     # @return [Boolean]
     def installed?
-      # Always force a refresh of cache
-      false
+      install_path.exist?
     end
 
     def http_client

--- a/lib/cookbook-omnifetch/chef_server_artifact.rb
+++ b/lib/cookbook-omnifetch/chef_server_artifact.rb
@@ -45,8 +45,7 @@ module CookbookOmnifetch
     #
     # @return [Boolean]
     def installed?
-      # Always force a refresh of cache
-      false
+      install_path.exist?
     end
 
     def http_client

--- a/lib/cookbook-omnifetch/exceptions.rb
+++ b/lib/cookbook-omnifetch/exceptions.rb
@@ -106,4 +106,9 @@ module CookbookOmnifetch
     end
   end
 
+  class StagingAreaNotAvailable < OmnifetchError
+    def initialize
+      super "failed to access a StagingArea that is no longer available"
+    end
+  end
 end

--- a/lib/cookbook-omnifetch/metadata_based_installer.rb
+++ b/lib/cookbook-omnifetch/metadata_based_installer.rb
@@ -1,5 +1,5 @@
 require_relative "threaded_job_queue"
-require "digest/md5"
+require "digest/md5" unless defined?(Digest::MD5)
 
 module CookbookOmnifetch
 

--- a/lib/cookbook-omnifetch/metadata_based_installer.rb
+++ b/lib/cookbook-omnifetch/metadata_based_installer.rb
@@ -1,4 +1,5 @@
 require_relative "threaded_job_queue"
+require_relative "staging_area"
 require "digest/md5" unless defined?(Digest::MD5)
 
 module CookbookOmnifetch
@@ -47,17 +48,20 @@ module CookbookOmnifetch
     end
 
     def install
-      metadata = http_client.get(url_path)
-      clean_cache(metadata)
-      sync_cache(metadata)
+      StagingArea.stage(install_path) do |staging_path|
+        FileUtils.cp_r("#{install_path}/.", staging_path) if Dir.exist?(install_path)
+        metadata = http_client.get(url_path)
+        clean_cache(staging_path, metadata)
+        sync_cache(staging_path, metadata)
+      end
     end
 
     # Removes files from cache that are not supposed to be there, based on
     # files in metadata.
-    def clean_cache(metadata)
-      actual_file_list = Dir.glob(File.join(install_path, "**/*"))
+    def clean_cache(staging_path, metadata)
+      actual_file_list = Dir.glob(File.join(staging_path, "**/*"))
       expected_file_list = []
-      CookbookMetadata.new(metadata).files { |_, path, _| expected_file_list << File.join(install_path, path) }
+      CookbookMetadata.new(metadata).files { |_, path, _| expected_file_list << File.join(staging_path, path) }
 
       extra_files = actual_file_list - expected_file_list
       extra_files.each do |path|
@@ -69,10 +73,10 @@ module CookbookOmnifetch
 
     # Downloads any out-of-date files into installer cache, overwriting
     # those that don't match the checksum provided the metadata @ url_path
-    def sync_cache(metadata)
+    def sync_cache(staging_path, metadata)
       queue = ThreadedJobQueue.new
       CookbookMetadata.new(metadata).files do |url, path, checksum|
-        dest_path = File.join(install_path, path)
+        dest_path = File.join(staging_path, path)
         FileUtils.mkdir_p(File.dirname(dest_path))
         if file_outdated?(dest_path, checksum)
           queue << lambda do |_lock|

--- a/lib/cookbook-omnifetch/staging_area.rb
+++ b/lib/cookbook-omnifetch/staging_area.rb
@@ -1,0 +1,190 @@
+module CookbookOmnifetch
+  # A staging area in which the caller can stage files and publish them to a
+  # local directory.
+  #
+  # When performing long operations such as installing or updating a cookbook
+  # from the web, {StagingArea} allows you to minimize the risk that a process
+  # running in parallel might retrieve an incomplete cookbook from the local
+  # cache before it is completely installed. (See {publish!} for details.)
+  #
+  # {StagingArea} allocates temporary directories on the local file system.  It
+  # is the caller's responsibility to use {discard!} when it is done to remove
+  # those directories.  The {.stage} method handles directory cleanup for the
+  # staging area it creates before returning.
+  #
+  # @example installing files using the {.stage} helper
+  #   CookbookOmnifetch::StagingArea.stage(install_path) do |staging_path|
+  #     # Copy files to staging_path
+  #   end
+  #
+  # @example creating a staging area and publishing it manually
+  #   stage = CookbookOmnifetch::StagingArea.new
+  #   # Copy files to stage.path
+  #   stage.publish!(install_path)
+  #   stage.discard!
+  class StagingArea
+    # Creates a staging area, calls a block to populate it, then publishes it.
+    #
+    # {stage} creates a staging area and calls the provided block to populate it
+    # with files. If the staging area does not contain any changes for
+    # +target_path+ (see {#match?}), it cleans up the staging area without
+    # modifying +target_path+.  Otherwise, it publishes its contents to
+    # +target_path+ and deletes the staging area.  As a safety measure, {stage}
+    # will not publish an empty staging area.
+    #
+    # @param [Pathname] target_path
+    #   directory to which the staging area will publish its contents
+    #
+    # @yieldparam staging_path [Pathname]
+    #   the directory in which the block should stage its files
+    def self.stage(target_path)
+      sa = new
+      begin
+        yield(sa.path)
+        sa.publish!(target_path) unless sa.empty? || sa.match?(target_path)
+      ensure
+        sa.discard!
+      end
+    end
+
+    # Returns true if the staging area is no longer available for use.
+    #
+    # The staging area is no longer available once {discard!} removes it from
+    # the file system.
+    #
+    # @return [Boolean] whether the staging area is unavailable
+    def unavailable?
+      !!@unavailable
+    end
+
+    # Returns true if the staging area is empty.
+    #
+    # A staging area is considered empty when it has no files or directories in
+    # its path or the staging directory does not exist.
+    #
+    # @raise [StagingAreaNotAvailable]
+    #   when called after the staging area destroyed with {discard!}
+    #
+    # @return [Boolean] whether the staging area is empty
+    def empty?
+      !path.exist? || path.empty?
+    end
+
+    # Returns true if the staging area's contents match those of a given path.
+    #
+    # {#match?} compares the contents of the staging area with the contents of
+    # the +compare_path+.  It considers the staging area to match if it contains
+    # all of and nothing more than the files and directories present in
+    # +compare_path+ and the content of each file is the same as that of its
+    # corresponding file in +compare_path+.  {match?} does not compare file
+    # metadata or the contents of special files.
+    #
+    # @param [String] compare_path
+    #   the directory to which the staging area will compare its contents
+    #
+    # @raise [StagingAreaNotAvailable]
+    #   when called after the staging area destroyed with {discard!}
+    #
+    # @return [Boolean] whether the staging area matches +compare_path+
+    def match?(compare_path)
+      raise StagingAreaNotAvailable if unavailable?
+
+      target = Pathname(compare_path)
+      return false unless target.exist?
+
+      files = Dir.glob("**/*", File::FNM_DOTMATCH, base: path)
+      target_files = Dir.glob("**/*", File::FNM_DOTMATCH, base: target)
+      return false unless files.sort == target_files.sort
+
+      files.each do |subpath|
+        return false if files_different?(path, target, subpath)
+      end
+
+      true
+    end
+
+    # Path to the staging folder on the file system.
+    #
+    # @raise [StagingAreaNotAvailable]
+    #   when called after the staging area destroyed with {discard!}
+    #
+    # @return [Pathname] path to the staging folder
+    def path
+      raise StagingAreaNotAvailable if unavailable?
+
+      return @path unless @path.nil?
+
+      # Dir.mktmpdir returns a directory with restrictive permissions that it
+      # doesn't support modifying, so create a subdirectory under it with
+      # regular permissions for staging.
+      @stage_tmp = Dir.mktmpdir
+      @path = Pathname.new(File.join(@stage_tmp, "staging"))
+      FileUtils.mkdir(@path)
+      @path
+    end
+
+    # Removes the staging area and its contents from the file system.
+    #
+    # The staging area is no longer available once {discard!} removes it from
+    # the file system.  Future attempts to use it will raise
+    # {StagingAreaNotAvailable}.
+    def discard!
+      FileUtils.rm_rf(@stage_tmp) unless @stage_tmp.nil?
+      @unavailable = true
+    end
+
+    # Replaces +install_path+ with the contents of the staging area.
+    #
+    # {publish!} removes the target and copies the new content into place using
+    # two atomic file system operations.  This eliminates much of the risk
+    # associated with updating the target in a multiprocess environment by
+    # ensuring that another process does not see a partially removed or
+    # populated directory at the +target_path+ while this operation is being
+    # performed.
+    #
+    # Note that it is still possible for the {publish!} to interrupt another
+    # process performing a long operation, such as creating a recursive copy of
+    # the target.  In this situation, the other process may create a copy that
+    # consists of a combination of content from the old target directory and the
+    # newly staged files.  The other process may also raise an exception should
+    # it try to access the target during a small window in the {publish!}
+    # operation where the target directory does not exist, or tries to open a
+    # file that is no longer part of the target tree after {publish!} completes.
+    # The other process can detect this situation by verifying that the content
+    # of its copy matches the content of +target_path+ after its copy is
+    # complete.
+    #
+    # @param [String] install_path
+    #   directory to which the staging area will publish its contents
+    #
+    # @raise [StagingAreaNotAvailable]
+    #   when called after the staging area destroyed with {discard!}
+    def publish!(install_path)
+      target = Pathname(install_path)
+      cache_dir = target.parent
+      cache_dir.mkpath
+      Dir.mktmpdir("_STAGING_TMP_", cache_dir) do |tmpdir|
+        newtmp = File.join(tmpdir, "new_cookbook")
+        oldtmp = File.join(tmpdir, "old_cookbook")
+        FileUtils.cp_r(path, newtmp)
+
+        # We could achieve an atomic replace using symbolic links, if they are
+        # supported on all platforms.
+        File.rename(target, oldtmp) if target.exist?
+        File.rename(newtmp, target)
+      end
+    end
+
+    private
+
+    # compares two files
+    def files_different?(base1, base2, subpath)
+      file1 = File.join(base1, subpath)
+      file2 = File.join(base2, subpath)
+      return true unless File.ftype(file1) == File.ftype(file2)
+      return true if File.file?(file1) && !FileUtils.cmp(file1, file2)
+
+      false
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,7 @@ module Fixtures
   end
 
   def spec_root
-    Pathname.new(File.expand_path(File.dirname(__FILE__)))
+    Pathname.new(__dir__)
   end
 
 end

--- a/spec/unit/chef_server_artifact_spec.rb
+++ b/spec/unit/chef_server_artifact_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require "cookbook-omnifetch/chef_server.rb"
+require "cookbook-omnifetch/chef_server"
 
 RSpec.describe CookbookOmnifetch::ChefServerArtifactLocation do
 

--- a/spec/unit/chef_server_spec.rb
+++ b/spec/unit/chef_server_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require "cookbook-omnifetch/chef_server.rb"
+require "cookbook-omnifetch/chef_server"
 
 RSpec.describe CookbookOmnifetch::ChefServerLocation do
 

--- a/spec/unit/metadata_based_installer_spec.rb
+++ b/spec/unit/metadata_based_installer_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require "cookbook-omnifetch/metadata_based_installer.rb"
+require "cookbook-omnifetch/metadata_based_installer"
 
 RSpec.shared_context "sample_metadata" do
 

--- a/spec/unit/staging_area_spec.rb
+++ b/spec/unit/staging_area_spec.rb
@@ -1,0 +1,295 @@
+require "spec_helper"
+require "cookbook-omnifetch/staging_area"
+
+RSpec.configure do |rspec|
+  rspec.shared_context_metadata_behavior = :apply_to_host_groups
+end
+
+RSpec.describe CookbookOmnifetch::StagingArea do
+  # Create a work area on the file system for setting up tests and clean it up
+  # after each test.
+  let(:test_area) { Pathname(Dir.mktmpdir(nil, Dir.tmpdir)) }
+  after do
+    FileUtils.rm_r(test_area)
+  end
+  let(:test_area_tmp) { test_area }
+
+  # Make Dir.mktmpdir allocate temporary directories in the test area so that
+  # they get cleaned up with the rest of the test area.
+  before do
+    allow(Dir).to receive(:mktmpdir).and_call_original
+    allow(Dir).to receive(:mktmpdir).with(no_args) do
+      Dir.mktmpdir("fake_tmpdir", test_area)
+    end
+  end
+
+  let(:cache_path)  { test_area.join("fake_cache") }
+  let(:target_path) { test_area.join("fake_cache", "fake_cookbook-1.2.3") }
+
+  let(:cookbook_fixture_path) do
+    fixtures_path.join("cookbooks", "example_cookbook")
+  end
+  def populate_from_fixture(dest_path)
+    dest_path.parent.mkpath
+    FileUtils.cp_r("#{cookbook_fixture_path}/.", dest_path)
+  end
+
+  let(:staging_area) { described_class.new }
+
+  describe("::stage") do
+    before do
+      allow(described_class).to receive(:new).and_return(staging_area)
+    end
+
+    it "publishes the staging area when it contains updates" do
+      expect(staging_area).to receive(:publish!)
+      described_class.stage(target_path) do |path|
+        populate_from_fixture(path)
+      end
+    end
+
+    it "does not publish the staging area when it has no updates" do
+      expect(staging_area).to_not receive(:publish!)
+      described_class.stage(target_path) { |_path| }
+    end
+
+    it "cleans up the staging area when the block raises an exception" do
+      expect(staging_area).to receive(:discard!)
+      expect do
+        described_class.stage(target_path) do |_path|
+          raise "FAKE ERROR"
+        end
+      end.to raise_exception("FAKE ERROR")
+    end
+  end
+
+  describe("#unavailable?") do
+    it "is initially false" do
+      expect(staging_area).to_not be_unavailable
+    end
+  end
+
+  describe("#empty?") do
+    it "is true when the staging area does not contain files" do
+      expect(staging_area).to be_empty
+    end
+
+    it "is true when the staging area is removed from the file system" do
+      staging_area.path.unlink
+
+      expect(staging_area).to be_empty
+    end
+
+    it "is false when the staging area contains a file" do
+      staging_area.path.join("test_file").write("TEST CONTENT")
+
+      expect(staging_area).to_not be_empty
+    end
+  end
+
+  describe("#path") do
+    it "returns a Pathname" do
+      expect(staging_area.path).to be_a(Pathname)
+    end
+
+    it "returns the path to a folder" do
+      expect(staging_area.path).to be_directory
+    end
+
+    it "returns the same staging area when called twice" do
+      expect(staging_area.path).to eq(staging_area.path)
+    end
+
+    it "provides a staging area in the temporary directory" do
+      expect(staging_area.path.to_s).to start_with(test_area_tmp.to_s)
+    end
+
+    # Temporary directories have restrictive permissions not suitable for
+    # the local cache.
+    it "provides a staging area with regular permissions" do
+      # test_area was created by mktmpdir and has restrictive permissions.
+      tmp_perms = File::Stat.new(test_area).mode
+
+      regular_dir = test_area.join("regular_dir")
+      regular_dir.mkdir
+      default_perms = File::Stat.new(regular_dir).mode
+
+      # Don't produce a false success if run with a umask of 077.
+      msg = "umask is too restrictive to perform this test"
+      skip(msg) if default_perms == tmp_perms
+
+      expect(File::Stat.new(staging_area.path).mode.to_s(8))
+        .to eq(default_perms.to_s(8))
+    end
+  end
+
+  describe("#match?") do
+    it "is true when target contains an identical cookbooks" do
+      populate_from_fixture(target_path)
+      populate_from_fixture(staging_area.path)
+
+      expect(staging_area).to be_match(target_path)
+    end
+
+    it "is false when the staging area does not exist" do
+      populate_from_fixture(target_path)
+      staging_area.path.unlink
+      expect(staging_area).to_not be_match(target_path)
+    end
+
+    it "is false when staging has content and" +
+      " the cache directory does not exist" do
+        populate_from_fixture(staging_area.path)
+
+        expect(staging_area).to_not be_match(target_path)
+      end
+
+    it "is false when the staging area has a recipe not in the target" do
+      populate_from_fixture(target_path)
+      populate_from_fixture(staging_area.path)
+      file = staging_area.path.join("recipes", "panna_cotta.rb")
+      file.write("# apply a tart berry glaze")
+
+      expect(staging_area).to_not be_match(target_path)
+    end
+
+    it "is false when the staging area is missing a dot-file from the target" do
+      populate_from_fixture(target_path)
+      populate_from_fixture(staging_area.path)
+      staging_area.path.join(".gitignore").unlink
+
+      expect(staging_area).to_not be_match(target_path)
+    end
+
+    it "is false when README.md has a different file type than in the target" do
+      populate_from_fixture(target_path)
+      populate_from_fixture(staging_area.path)
+      file_path = staging_area.path.join("README.md")
+      file_path.unlink
+      file_path.mkdir
+
+      expect(staging_area).to_not be_match(target_path)
+    end
+
+    it "is false when README.md has different content" do
+      populate_from_fixture(target_path)
+      populate_from_fixture(staging_area.path)
+      file_path = staging_area.path.join("README.md")
+      expect(file_path).to exist
+      file_path.write("this is not the file you are looking for")
+
+      expect(staging_area).to_not be_match(target_path)
+    end
+  end
+
+  describe("#discard!") do
+    it "removes the temporary directory that held the staging area" do
+      staging_area.path
+
+      staging_area.discard!
+
+      expect(test_area).to be_empty
+    end
+
+    it "makes the staging area unavailble" do
+      staging_area.discard!
+
+      expect(staging_area).to be_unavailable
+    end
+  end
+
+  describe("#publish!") do
+    it "creates the cache directory when it does not exist" do
+      expect(cache_path).to_not exist
+
+      staging_area.publish!(target_path)
+
+      expect(cache_path).to exist
+    end
+
+    it "uses the cache directory if it already exists" do
+      other_cookbook = cache_path.join("other_cookbook-0.0.1")
+      populate_from_fixture(other_cookbook)
+
+      staging_area.publish!(target_path)
+
+      expect(other_cookbook).to exist
+    end
+
+    it "copies files from the staging area to the target" do
+      populate_from_fixture(staging_area.path)
+
+      staging_area.publish!(target_path)
+
+      expect(target_path.join("recipes", "default.rb")).to exist
+      expect(staging_area.path.join("recipes", "default.rb")).to exist
+    end
+
+    it "replaces the target directory if it already exists" do
+      populate_from_fixture(staging_area.path)
+      target_path.mkpath
+      orig_inode = File::Stat.new(target_path).ino
+
+      staging_area.publish!(target_path)
+
+      expect(File::Stat.new(target_path).ino).to_not eq(orig_inode)
+    end
+
+    it "replaces the target near-atomically" do
+      # Near-atomic replacement of the target is an important part of
+      # StagingArea's contract.  Rspec cannot reliably test whether an operation
+      # is performs atomically, so the only way this test can verify that the
+      # requirement is met is to check that it is implemented in a specific way.
+      # :(
+
+      populate_from_fixture(staging_area.path)
+      populate_from_fixture(target_path)
+
+      # Directory renames are atomic file system operations when the source and
+      # destination reside on the same file system.  Ensure that the destination
+      # when moving the old release out of the way, and the source when moving
+      # the new release into place are located somewhere under the parent
+      # directory of the target.
+      expect(File).to receive(:rename)
+        .with(target_path, start_with(target_path.parent.to_s)).ordered
+      expect(File).to receive(:rename)
+        .with(start_with(target_path.parent.to_s), target_path).ordered
+      staging_area.publish!(target_path)
+    end
+  end
+
+  context "when the staging area is not available" do
+    before do
+      staging_area.discard!
+    end
+
+    it "#unavailable? is true" do
+      expect(staging_area).to be_unavailable
+    end
+
+    it "#empty? raises StagingAreaNotAvailable" do
+      expect { staging_area.empty? }
+        .to raise_exception(CookbookOmnifetch::StagingAreaNotAvailable)
+    end
+
+    it "#match? raises StagingAreaNotAvailable" do
+      expect { staging_area.match?(target_path) }
+        .to raise_exception(CookbookOmnifetch::StagingAreaNotAvailable)
+    end
+
+    it "#path raises StagingAreaNotAvailable" do
+      expect { staging_area.path }
+        .to raise_exception(CookbookOmnifetch::StagingAreaNotAvailable)
+    end
+
+    it "#publish! raises StagingAreaNotAvailable" do
+      expect { staging_area.publish!(target_path) }
+        .to raise_exception(CookbookOmnifetch::StagingAreaNotAvailable)
+    end
+
+    it "#discard! does not raise an error" do
+      expect { staging_area.discard! }
+        .to_not raise_exception
+    end
+  end
+end


### PR DESCRIPTION
## Description

__IMPORTANT__:  _Unit tests pass with these changes, however, I have not yet completed any testing beyond that.  I am creating this P/R a little early so that @vkarve-chef can discuss it with his team at next week's sprint planning meeting._

Restore the previous functionality of `installed?` to resolve #35.  This is rolling back a part of #33 critical for "fixing" chef/chef-workstation#1273, though as I noted on that issue, #33 doesn't really resolve all of chef/chef-workstation#1273.  (I believe the correct solution for chef/chef-workstation#1273 is to make `PolicyfileCompiler` in [chef-cli](https://github.com/chef/chef-cli) always call `install` while the `CookbookLock` continues to use the existing `ensure_cached` functionality and hope to discuss that more in the appropriate thread.)

#33 also removed the staging functionality from the chef server location objects that was used to prevent other processes from retrieving partially installed cookbooks from the cache.  It didn't seem necessary when every process tried to re-install the cookbook to the cache before using it, but #35 shows it isn't always practical to this, so the staging functionality is needed again.

All installers that store cookbooks in the cache need to use a staging area to address this problem.  This code is implemented and tested in slightly different ways across each of the installers.  Instead of restoring the previous staging implementation, this PR introduces a new `StagingArea` object suitable for use by any of the installers that we can use to reduce this code duplication and the maintenance burden associated with it.

## Related Issue
#35 and chef/chef-workstation#1273

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] __REVERT A__ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
