### PR TITLE
Minor: add missing require

### DIFF
--- a/lib/cookbook-omnifetch/staging_area.rb
+++ b/lib/cookbook-omnifetch/staging_area.rb
@@ -1,3 +1,5 @@
+require_relative "exceptions"
+
 module CookbookOmnifetch
   # A staging area in which the caller can stage files and publish them to a
   # local directory.


### PR DESCRIPTION
This is a trivial fix and not urgent.  Sorry, I just found that I still had an update in my working directory.  This was supposed to be part of #41, but it looks like it missed the `git add`.  Without this, `StagingArea` will generate a `NameError` instead of raising `StagingAreaNotAvailable` in certain situations.  I do not believe the current code base can create a situation in which this would happen, but it should still be fixed.