### PR TITLE
changing revision to parse default as main from master

### DIFF
--- a/lib/cookbook-omnifetch/git.rb
+++ b/lib/cookbook-omnifetch/git.rb
@@ -23,7 +23,7 @@ module CookbookOmnifetch
       @rel      = options[:rel]
 
       # The revision to parse
-      @rev_parse = options[:ref] || options[:branch] || options[:tag] || "master"
+      @rev_parse = options[:ref] || options[:branch] || options[:tag] || "main"
     end
 
     # @see BaseLoation#installed?

--- a/spec/unit/git_spec.rb
+++ b/spec/unit/git_spec.rb
@@ -1,5 +1,6 @@
 require "spec_helper"
 require "cookbook-omnifetch/git"
+require 'pathname'
 
 module CookbookOmnifetch
   describe GitLocation do

--- a/spec/unit/git_spec.rb
+++ b/spec/unit/git_spec.rb
@@ -69,9 +69,9 @@ module CookbookOmnifetch
           expect(rev_parse(instance)).to eq("v1.2.3")
         end
 
-        it 'uses "master" when none is given' do
+        it 'uses "main" when none is given' do
           instance = described_class.new(dependency, git: "https://repo.com")
-          expect(rev_parse(instance)).to eq("master")
+          expect(rev_parse(instance)).to eq("main")
         end
       end
     end

--- a/spec/unit/git_spec.rb
+++ b/spec/unit/git_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 require "cookbook-omnifetch/git"
-require 'pathname'
+require "pathname"
 
 module CookbookOmnifetch
   describe GitLocation do


### PR DESCRIPTION
Signed-off-by: Pranay Singh <i5singh.pranay@gmail.com>

changing revision to parse default as main from master, when none is given

## Related Issue
https://github.com/chef/chef-workstation/issues/2761

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
