### PR TITLE
Updated ruby dependency

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -1,13 +1,5 @@
 ---
 steps:
-- label: run-specs-ruby-2.6
-  command:
-    - .expeditor/run_linux_tests.sh
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.6
-
 - label: run-specs-ruby-2.7
   command:
     - .expeditor/run_linux_tests.sh

--- a/cookbook-omnifetch.gemspec
+++ b/cookbook-omnifetch.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/chef/cookbook-omnifetch"
   spec.license       = "Apache-2.0"
 
-  spec.required_ruby_version = ">= 2.5"
+  spec.required_ruby_version = ">= 2.7"
 
   spec.files         = `git ls-files -z`.split("\x0").grep(/LICENSE|^lib/)
   spec.require_paths = ["lib"]


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Updated ruby dependency and removing  ruby 2.6 verify pipeline

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
