### PR TITLE
CHEF-26915 - standardize - remove_sla_from_readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,6 @@
 [![Gem Version](https://badge.fury.io/rb/cookbook-omnifetch.svg)](https://badge.fury.io/rb/cookbook-omnifetch)
 [![Build status](https://badge.buildkite.com/3f3f8dc5b6c82b74fba32adaad641d004f622b304525d6386c.svg?branch=master)](https://buildkite.com/chef-oss/chef-cookbook-omnifetch-master-verify)
 
-**Umbrella Project**: [Chef Workstation](https://github.com/chef/chef-oss-practices/blob/master/projects/chef-workstation.md)
-
-* **[Project State](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md):** Active
-* **Issues [Response Time Maximum](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md):** 14 days
-* **Pull Request [Response Time Maximum](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md):** 14 days
-
 `CookbookOmnifetch` provides library code for fetching Chef cookbooks
 from an artifact server (usually https://supermarket.chef.io),
 git/github, a local path, or a chef-server to a local cache for


### PR DESCRIPTION
This pull request removes the oft-misleading Chef SLA text from the README.md file.

This action is being taken as part of the [2025 Repo Standardization Initiative](https://github.com/chef-boneyard/oss-repo-standardization-2025). 
As Progress Chef makes a best effort to respond to issues and pull requests in a timely manner, and prioritizes bugfixes and security updates on a customer-driven basis (which may span repos, or have no repo footprint at all), we no longer support the concept of a Service Level Agreement (SLA) on a repository-centric basis. For further details, see [Repo SLA Removal FAQ](https://github.com/chef-boneyard/oss-repo-standardization-2025/blob/main/messaging/sla-removal.md).